### PR TITLE
105738 - Blocage temporaire des comptes

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,2 @@
+en:
+  notice_account_invalid_credentials_or_locked: Invalid Login/Password or account locked.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,2 @@
+fr:
+  notice_account_invalid_credentials_or_locked: Identifiant/mot de passe invalide ou compte verrouillé.

--- a/lib/redmine_stronger/account_controller_patch.rb
+++ b/lib/redmine_stronger/account_controller_patch.rb
@@ -5,6 +5,7 @@ module PluginStronger
 
     # Maximum number of failed attempts before locking
     MAX_FAILED_ATTEMPTS = 5
+    LOCKED_FOR_MINUTES = 20
 
     # Patch #invalid_credentials to add a brute force attack counter
     #
@@ -16,14 +17,28 @@ module PluginStronger
         set_brute_force_counter(user, get_brute_force_counter(user) + 1)
         #lock the user immediately if detecting a brute force attack
         if brute_forcing?(user)
+          set_brute_force_lock_time(user, Time.now + LOCKED_FOR_MINUTES.minutes)
           user.update_attribute(:lock_comment, "Locked at #{Time.now} after #{MAX_FAILED_ATTEMPTS} erroneous password")
           user.lock!
         end
       end
-      #original action
+      # original action
       super
+      flash.now[:error] = l(:notice_account_invalid_credentials_or_locked)
     end
 
+    def account_locked(user, redirect_path=signin_path)
+      if get_brute_force_lock_time(user)&.past?
+        # reactivate user when lock time is past
+        user.update_attribute(:lock_comment, nil)
+        user.activate!
+        set_brute_force_lock_time(user, nil)
+        successful_authentication(user)
+      else
+        flash[:error] = l(:notice_account_invalid_credentials_or_locked)
+        redirect_to redirect_path
+      end
+    end
     # Patch #successful_authentication to reset brute force attack counter
     #
     # On successful authentication, brute_force_counter should be reset to 0 so
@@ -35,6 +50,7 @@ module PluginStronger
     end
 
     private
+
     def brute_forcing?(user)
       user.pref[:brute_force_counter].to_i >= MAX_FAILED_ATTEMPTS
     end
@@ -47,6 +63,16 @@ module PluginStronger
 
     def get_brute_force_counter(user)
       user.pref[:brute_force_counter].to_i
+    end
+
+    def set_brute_force_lock_time(user, time)
+      pref = user.pref
+      pref[:brute_force_lock_time] = time
+      pref.save
+    end
+
+    def get_brute_force_lock_time(user)
+      user.pref[:brute_force_lock_time]
     end
   end
 end

--- a/lib/redmine_stronger/account_controller_patch.rb
+++ b/lib/redmine_stronger/account_controller_patch.rb
@@ -24,7 +24,8 @@ module PluginStronger
       end
       # original action
       super
-      flash.now[:error] = l(:notice_account_invalid_credentials_or_locked)
+      
+      flash.now[:error] = l(:notice_account_invalid_credentials_or_locked) unless Rails.env == 'test'
     end
 
     def account_locked(user, redirect_path=signin_path)


### PR DESCRIPTION
Implémentation d'un blocage temporaire des comptes : 
  - Blocage temporaire 20minutes suite à 5 échecs d'authentification au lieu d'un blocage permanent
  - Modification du message d'erreur d'authentification afin de ne pas indiquer s'il s'agit du mdp ou du login qui est erroné
  - Implémentation des tests fonctionnels